### PR TITLE
Allow MaskingCharConfig be Empty for Blank Input

### DIFF
--- a/client/src/components/DeidentificationConfigForm.js
+++ b/client/src/components/DeidentificationConfigForm.js
@@ -51,9 +51,15 @@ export class DeidentificationConfigForm extends React.Component {
 
   handleMaskingCharChange = (event) => {
     const maskingChar = event.target.value;
-    this.updateDeidStep({
-      maskingCharConfig: { maskingChar: maskingChar }
-    });
+    if (maskingChar) {
+      this.updateDeidStep({
+        maskingCharConfig: { maskingChar: maskingChar }
+      });
+    } else {
+      this.updateDeidStep({
+        maskingCharConfig: {}
+      });
+    }
   }
 
   handleConfidenceThresholdChange = (event) => {


### PR DESCRIPTION
If the "masking char" input field is blank, set the value of `maskingCharConfig` to an empty object `{}`. When this gets sent to the server, it will pick `*` as the default value for `maskingChar`.