### PR TITLE
Update stack with the best-performing open tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,25 @@ React client for the NLP Sandbox PHI Deidentifier API
 
 ## Usage
 
-The PHI Deidentifier runs on a dockerized stack. First, make sure that you have [installed Docker](https://docs.docker.com/get-docker/)
-in your local environment. Once you have done that, move your working directory to this directory, then run the
-following command to start up the stack:
+## Running with Docker
 
-```
-$ docker-compose up
+Create the configuration file.
+
+```console
+cp .env.example .env
 ```
 
-When running, the Deidentifier stacks provides a web interface at [localhost](http://localhost) that you can use to test
-out a selection of annotators on a clinical note.
+The command below starts the PHI de-identifier locally.
+
+```console
+docker-compose up
+```
+
+You can stop the stack with `Ctrl+C`. Add the option `-d` to the above command
+to run the stack in detached mode. To stop a stack in detached mode, run
+`docker-compose down` from this project folder.
+
+The app should now be available on http://localhost.
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,16 @@ version: "3.8"
 
 services:
   date-annotator:
-    image: docker.synapse.org/syn22277123/date-annotator-example:1.2.0
+    # image: docker.synapse.org/syn22277123/date-annotator-example:1.2.0
+    image: docker.synapse.org/syn22277123/phi-annotator-neuroner:1.1.1
     container_name: date-annotator
     restart: always
     networks:
       - nlpsandbox-internal
 
   person-name-annotator:
-    image: docker.synapse.org/syn22277123/person-name-annotator-example:1.2.0
+    # image: docker.synapse.org/syn22277123/person-name-annotator-example:1.2.0
+    image: docker.synapse.org/syn22277123/phi-annotator-huggingface-bert-base-ner-uncased:1.2.0
     container_name: person-name-annotator
     restart: always
     networks:
@@ -23,19 +25,21 @@ services:
       - nlpsandbox-internal
 
   contact-annotator:
-    image: docker.synapse.org/syn22277123/contact-annotator-example:1.2.0
+    # image: docker.synapse.org/syn22277123/contact-annotator-example:1.2.0
+    image: docker.synapse.org/syn22277123/phi-annotator-neuroner:1.1.1
     container_name: contact-annotator
     restart: always
     networks:
       - nlpsandbox-internal
 
   id-annotator:
-    image: docker.synapse.org/syn22277123/id-annotator-example:1.2.0
+    # image: docker.synapse.org/syn22277123/id-annotator-example:1.2.0
+    image: docker.synapse.org/syn22277123/phi-annotator-neuroner:1.1.1
     container_name: id-annotator
     restart: always
     networks:
       - nlpsandbox-internal
-    
+
   phi-deidentifier:
     image: docker.synapse.org/syn22277123/phi-deidentifier-example:1.3.0
     container_name: phi-deidentifier


### PR DESCRIPTION
Update the stack to use the best-performing NLP Sandbox tools for each tasks.

## Notes

- Update instructions on how to run the stack using docker (was missing the creation of the config file)
- Spark NLP models are the best-performing tools in most tasks. However, I decided to not include them because they are private models.
- Keep the example location annotator because NeuroNER fails to detect "Seattle" from the example note.
- De-identifying the first note takes some times as the tools initialize. For instance, NLP Spark and NeuroNER may take about ~20 seconds to initialize. Note that this is only for the first note processed by the stack, not the first note de-identified by a user. Therefore, the person who updates the stack and starts it should systematically de-identify at least one note so that the next user does not have to wait.

## Preview

![image](https://user-images.githubusercontent.com/3056480/150576161-d3346fb2-aef5-44ed-a246-f41e71f26f19.png)

![image](https://user-images.githubusercontent.com/3056480/150576332-1cc2204b-e40d-4e27-a4cd-4bebbb9d80b6.png)

